### PR TITLE
MRADEV-655 fix upload error

### DIFF
--- a/app/src/main/java/com/nginx/image/core/PhotoResizer.java
+++ b/app/src/main/java/com/nginx/image/core/PhotoResizer.java
@@ -113,7 +113,9 @@ public class PhotoResizer {
             File originalImage = File.createTempFile(ImageSizeEnum.LARGE.getSizeName() + "_", extension, repository);
 
             // http://s3.amazonaws.com/path/original.jpg
-            Download originalDownload = s3Client.download(baseImagePath, originalImage, extension);
+            Download originalDownload = s3Client.download(
+                    baseImagePath.replace("/" + s3Client.getExistingBucketName() + "/", "") + "original" + extension,
+                    originalImage);
 
             if (!originalDownload.isDone()) {
                 LOGGER.info("Transfer: " + originalDownload.getDescription());

--- a/app/src/main/java/com/nginx/image/net/S3Client.java
+++ b/app/src/main/java/com/nginx/image/net/S3Client.java
@@ -58,10 +58,9 @@ public class S3Client {
 
     }
 
-    public Download download(String baseImagePath, File originalImage, String extension) {
-        LOGGER.info("======= S3Client download: " + baseImagePath + ", file: " + originalImage);
-        return transferManager.download(existingBucketName,
-                baseImagePath.replace("/" + existingBucketName + "/", "") + "original" + extension, originalImage);
+    public Download download(String baseImagePath, File originalImage) {
+        LOGGER.info("S3Client download: " + baseImagePath + ", file: " + originalImage);
+        return transferManager.download(existingBucketName, baseImagePath, originalImage);
     }
 
 
@@ -123,5 +122,12 @@ public class S3Client {
         return true;
     }
 
-
+    /**
+     * Getter for existingBucketName
+     *
+     * @return java.lang.String
+     */
+    public String getExistingBucketName() {
+        return existingBucketName;
+    }
 }

--- a/app/src/test/java/com/nginx/image/core/PhotoResizerTest.java
+++ b/app/src/test/java/com/nginx/image/core/PhotoResizerTest.java
@@ -12,7 +12,6 @@ import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.glassfish.jersey.client.JerseyClientBuilder;
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -74,7 +73,7 @@ public class PhotoResizerTest  {
             Object[] args = invocation.getArguments();
             FileUtils.copyFile(resourceFile, (File)args[1]);
             return new MockDownload();
-        }).when(mockS3).download(anyString(), any(File.class), anyString());
+        }).when(mockS3).download(anyString(), any(File.class));
 
         when(mockS3.fileUpload(any(), anyString())).thenReturn(Boolean.TRUE);
 


### PR DESCRIPTION
Fix error caused by only letting jpg images get resized. Resizer now allows images of any type to be resized. However, the error could not be completely eliminated. Part of the reason we were getting this is because of a bug caused by multer - a library we are using to upload images. In the error that occurs, the upload of the image works fine but when we attempt to access the location of the image it errors out - returning 'TODO: implement' rather than an image location.